### PR TITLE
Transcribes `pdf/pages/4.pdf` to `pages/4.md` covering:
- Localization of ideals ($I_\mathfrak{p} = IA_\mathfrak{p}$)
- Corollary 2.7 (ideal = intersection of localizations)
- Example 2.8 ($\mathbb{Z} = \bigcap_p \mathbb{Z}_{(p)}$)
- Discussion paragraph on the power of local rings
- §2.4 Dedekind domains
- Proposition 2.9 (equivalent characterizations: DVR localizations ↔ integrally closed + dim ≤ 1)
- Proof of (i)⟹(ii) and start of (ii)⟹(i), ending mid-proof

Page ends mid-proof of Proposition 2.9; continuation on page 5.

Closes #12

🤖 Prepared with Claude Code

### DIFF
--- a/pages/4.md
+++ b/pages/4.md
@@ -1,0 +1,29 @@
+An important special case of this proposition occurs when $K = \operatorname{Frac} A$ and $V = K$, in which case $M$ is an $A$-submodule of $K$. Every ideal $I$ of $A$ is an $A$-submodule of $K$, and can thus be localized as above. The localization of $I$ (as an $A$-module) at a prime ideal $\mathfrak{p}$ of $A$ is the same thing as the extension of $I$ (as an $A$-ideal) to the localization of $A$ at $\mathfrak{p}$. In other words,
+
+$$I_{\mathfrak{p}} = \{i/s : i \in I, s \in A - \mathfrak{p}\} = \{ia/s : i \in I, a \in A, s \in A - \mathfrak{p}\} = IA_{\mathfrak{p}}.$$
+
+We also have the following corollary of Proposition 2.6.
+
+**Corollary 2.7.** *Let $A$ be an integral domain. Every ideal $I$ of $A$ (including $I = A$) is equal to the intersection of its localizations at the maximal ideals of $A$, and also to the intersection of its localizations at the prime ideals of $A$.*
+
+**Example 2.8.** If $A = \mathbb{Z}$ then $\mathbb{Z} = \bigcap_p \mathbb{Z}_{(p)}$ in $\mathbb{Q}$.
+
+Proposition 2.6 and Corollary 2.7 are powerful tools, because they allow us to work in local rings (rings with just one maximal ideal), which often simplifies matters considerably. For example, to prove that an ideal $I$ in an integral domain $A$ satisfies a certain property, it is enough to show that this property holds for all its localizations $I_{\mathfrak{p}}$ at prime ideals $\mathfrak{p}$ and is preserved under intersections. We now want to consider rings $A$ that satisfy some further assumptions that make its localizations even easier to work with.
+
+## 2.4 Dedekind domains
+
+**Proposition 2.9.** *Let $A$ be a noetherian domain. The following are equivalent:*
+
+*(i) For every nonzero prime ideal $\mathfrak{p} \subset A$ the local ring $A_{\mathfrak{p}}$ is a DVR.*
+
+*(ii) The ring $A$ is integrally closed and $\dim A \leq 1$.*
+
+*Proof.* If $A$ is a field then (i) and (ii) both hold, so let us assume that $A$ is not a field, and put $K := \operatorname{Frac} A$. We first show that (i) implies (ii). Recall that $\dim A$ is the supremum of the length of all chains of prime ideals. It follows from Theorem 2.1 that every chain of prime ideals $(0) \subsetneq \mathfrak{p}_1 \subsetneq \cdots \subsetneq \mathfrak{p}_n$ extends to a corresponding chain in $A_{\mathfrak{p}_n}$ of the same length; conversely, every chain in $A_{\mathfrak{p}}$ contracts to a chain in $A$ of the same length. Thus
+
+$$\dim A = \sup\{\dim A_{\mathfrak{p}} : \mathfrak{p} \in \operatorname{Spec} A\} = 1,$$
+
+since every $A_{\mathfrak{p}}$ is either a DVR ($\mathfrak{p} \neq (0)$), in which case $\dim A_{\mathfrak{p}} = 1$, or a field ($\mathfrak{p} = (0)$), in which case $\dim A_{\mathfrak{p}} = 0$. Any $x \in K$ that is integral over $A$ is integral over every $A_{\mathfrak{p}}$ (since they all contain $A$), and the $A_{\mathfrak{p}}$ are integrally closed, since they are DVRs or fields. So $x \in \bigcap_{\mathfrak{p}} A_{\mathfrak{p}} = A$, and therefore $A$ is integrally closed, which shows (ii).
+
+To show that (ii) implies (i), we first show that the following properties are all inherited by localizations of a ring: (1) no zero divisors, (2) noetherian, (3) dimension at most one, (4) integrally closed. (1) is obvious, (2) was noted in Remark 2.2, and (3) follows from Theorem 2.1 since, as argued above, we have $\dim A_{\mathfrak{p}} \leq \dim A$. To show (4), suppose $x \in K$ is integral over $A_{\mathfrak{p}}$. Then
+
+$$x^n + \frac{a_{n-1}}{s_{n-1}} x^{n-1} + \cdots + \frac{a_1}{s_1} x + \frac{a_0}{s_0} = 0$$


### PR DESCRIPTION
Closes #--title

Session: `c727b2ef-bf24-47e9-a299-b1366b5eccc9`

84e7c04 Transcribe page 4 (#12)

🤖 Prepared with Claude Code