### PR TITLE
Stage 1.5: Validate transcriptions (pages 1-7)

### DIFF
--- a/pages/CONVENTIONS.md
+++ b/pages/CONVENTIONS.md
@@ -80,7 +80,7 @@ The lecture cites:
 - Preserve the lecture's result numbering (Theorem 2.1, Definition 2.7, etc.).
 - Commutative diagrams: use display-math with `\xrightarrow`, `\downarrow`, `\nearrow` etc. on separate lines; do not attempt complex TikZ.
 - Page 1 ends mid-sentence at the start of §2.2; the continuation belongs to page 2.
-- Page 2 ends mid-example (Example 2.4); Example 2.5 begins page 3.
+- Page 2 ends after Example 2.4; Example 2.5 begins page 3.
 - Page 4 ends mid-proof (Proposition 2.9); the continuation belongs to page 5.
 - Page 5 ends after Lemma 2.14 (start of §2.5 Fractional ideals).
 - Page 6 ends mid-discussion after stating Lemma 2.20 and a remark before its proof; the proof belongs to page 7.


### PR DESCRIPTION
## Summary

- Validated all 7 transcribed pages (pages/1.md through pages/7.md) against their source PDFs
- Every mathematical formula, theorem statement, proof, equation number, footnote, and section heading matches the PDF
- No missing content, garbled text, or OCR artifacts found
- Fixed one minor inaccuracy in `pages/CONVENTIONS.md`: page 2 break note incorrectly said "ends mid-example (Example 2.4)" when Example 2.4 is fully complete on page 2

## Validation checklist

- [x] Page 1: §2.1 Localization of rings, commutative diagram, equation (1)
- [x] Page 2: §2.2 continuation, equation (2), Theorem 2.1, Remark 2.2, Warning 2.3, Example 2.4
- [x] Page 3: Example 2.5, §2.3 Localization of modules, Proposition 2.6 + proof
- [x] Page 4: Corollary 2.7, Example 2.8, §2.4 Dedekind domains, Proposition 2.9 + proof start
- [x] Page 5: Proof continuation, Def 2.10, Cor 2.11, Remark 2.12, §2.5, Def 2.13, Lemma 2.14
- [x] Page 6: Remark 2.15, Cor 2.16, Def 2.17, Lemma 2.18, Def 2.19, Lemma 2.20
- [x] Page 7: Proof of Lemma 2.20, Example 2.21, §2.6, Def 2.22-2.23, Example 2.24, Remark 2.25
- [x] LaTeX notation consistent with CONVENTIONS.md
- [x] Page breaks correctly handled
- [x] CONVENTIONS.md page break note fixed

Closes #25

🤖 Prepared with Claude Code