### PR TITLE
## Summary
- Created 32 `.refs.md` companion files in `blobs/Lecture2/` for items with Mathlib coverage or external source data
- Each file contains Mathlib declaration names (`#check` syntax), external source references, gap analysis, and suggested imports
- 7 items correctly skipped (discussion_only/not_applicable with no actionable references)
- Synthesizes data from `research/mathlib-coverage.json`, `research/external-sources.json`, and `dependencies/external.json`

## Verification
- Every item with `coverage != discussion_only` and `coverage != not_applicable` has a `.refs.md` file
- Every item with Mathlib declarations has those declarations listed with `#check` syntax
- Every item referenced by an external source has that source cited
- No item with coverage data is missing its reference file

Closes #55

🤖 Prepared with Claude Code

### DIFF
--- a/blobs/Lecture2/02_00a_Discussion.refs.md
+++ b/blobs/Lecture2/02_00a_Discussion.refs.md
@@ -1,0 +1,34 @@
+# References: Lecture2/02_00a_Discussion
+
+**Coverage:** fully_covered
+
+Localization S⁻¹A: definition, universal property, construction all in Mathlib.
+
+
+## Mathlib Declarations
+
+- `#check Localization`
+  - S⁻¹A as a type
+  - Import: `import Mathlib.RingTheory.Localization.Basic`
+- `#check IsLocalization`
+  - Typeclass for localization
+  - Import: `import Mathlib.RingTheory.Localization.Basic`
+- `#check Localization.mk`
+  - Constructor a/s for localization elements
+  - Import: `import Mathlib.RingTheory.Localization.Basic`
+- `#check IsLocalization.lift`
+  - Universal property of localization
+  - Import: `import Mathlib.RingTheory.Localization.Basic`
+- `#check IsFractionRing`
+  - Fraction field as localization at nonZeroDivisors
+  - Import: `import Mathlib.RingTheory.Localization.FractionRing`
+- `#check FractionRing`
+  - Concrete fraction field construction
+  - Import: `import Mathlib.RingTheory.Localization.FractionRing`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.Localization.Basic
+import Mathlib.RingTheory.Localization.FractionRing
+```

--- a/blobs/Lecture2/02_00b_Discussion.refs.md
+++ b/blobs/Lecture2/02_00b_Discussion.refs.md
@@ -1,0 +1,33 @@
+# References: Lecture2/02_00b_Discussion
+
+**Coverage:** fully_covered
+
+Ideal extension/contraction under localization; b = b^{ce} for localizations.
+
+
+## Mathlib Declarations
+
+- `#check Ideal.map`
+  - Extension of an ideal under a ring homomorphism
+  - Import: `import Mathlib.RingTheory.Ideal.Operations`
+- `#check Ideal.comap`
+  - Contraction of an ideal under a ring homomorphism
+  - Import: `import Mathlib.Order.GaloisConnection`
+- `#check IsLocalization.map_comap`
+  - b^{ce} = b for localizations (extension-contraction identity)
+  - Import: `import Mathlib.RingTheory.Localization.Ideal`
+
+## External Sources
+
+- **Atiyah & MacDonald, Introduction to Commutative Algebra** (textbook)
+  - Standard reference for commutative algebra. The lecture cites [1, Prop. 11.19] for contraction/extension properties and [1, Cor. 11.20] for the prime ideal correspondence (Theorem 2.1). These results 
+- **Artin, Algebra (2nd ed.)** (textbook)
+  - The lecture cites [2, Prop. 3.5] for the tensor-localization equivalence S⁻¹M ≅ M ⊗_A S⁻¹A, and [2, Prop. 3.11] for contraction/extension and prime ideal correspondence. These are in Mathlib but the t
+
+## Suggested Imports
+
+```lean
+import Mathlib.Order.GaloisConnection
+import Mathlib.RingTheory.Ideal.Operations
+import Mathlib.RingTheory.Localization.Ideal
+```

--- a/blobs/Lecture2/02_01_Theorem.refs.md
+++ b/blobs/Lecture2/02_01_Theorem.refs.md
@@ -1,0 +1,25 @@
+# References: Lecture2/02_01_Theorem
+
+**Coverage:** fully_covered
+
+Theorem 2.1 (prime ideal correspondence under localization) is fully in Mathlib as an order isomorphism.
+
+
+## Mathlib Declarations
+
+- `#check IsLocalization.orderIsoOfPrime`
+  - Order isomorphism between primes of S⁻¹A and primes of A disjoint from S
+  - Import: `import Mathlib.RingTheory.Localization.AtPrime`
+
+## External Sources
+
+- **Atiyah & MacDonald, Introduction to Commutative Algebra** (textbook)
+  - Standard reference for commutative algebra. The lecture cites [1, Prop. 11.19] for contraction/extension properties and [1, Cor. 11.20] for the prime ideal correspondence (Theorem 2.1). These results 
+- **Artin, Algebra (2nd ed.)** (textbook)
+  - The lecture cites [2, Prop. 3.5] for the tensor-localization equivalence S⁻¹M ≅ M ⊗_A S⁻¹A, and [2, Prop. 3.11] for contraction/extension and prime ideal correspondence. These are in Mathlib but the t
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.Localization.AtPrime
+```

--- a/blobs/Lecture2/02_02_Remark.refs.md
+++ b/blobs/Lecture2/02_02_Remark.refs.md
@@ -1,0 +1,27 @@
+# References: Lecture2/02_02_Remark
+
+**Coverage:** fully_covered
+
+Noetherian and PID preserved under localization, ideal generation in localizations.
+
+
+## Mathlib Declarations
+
+- `#check IsLocalization.isNoetherianRing`
+  - Localization of noetherian ring is noetherian
+  - Import: `import Mathlib.RingTheory.Localization.Module`
+- `#check Localization.AtPrime.isPrincipalIdealRing`
+  - Localization of PID at prime is PID
+  - Import: `import Mathlib.RingTheory.Localization.AtPrime`
+
+## External Sources
+
+- **Atiyah & MacDonald, Introduction to Commutative Algebra** (textbook)
+  - Standard reference for commutative algebra. The lecture cites [1, Prop. 11.19] for contraction/extension properties and [1, Cor. 11.20] for the prime ideal correspondence (Theorem 2.1). These results 
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.Localization.AtPrime
+import Mathlib.RingTheory.Localization.Module
+```

--- a/blobs/Lecture2/02_02a_Discussion.refs.md
+++ b/blobs/Lecture2/02_02a_Discussion.refs.md
@@ -1,0 +1,31 @@
+# References: Lecture2/02_02a_Discussion
+
+**Coverage:** fully_covered
+
+Localization at prime A_p, local ring structure, unique maximal ideal.
+
+
+## Mathlib Declarations
+
+- `#check Localization.AtPrime`
+  - Localization at a prime ideal A_p
+  - Import: `import Mathlib.RingTheory.Localization.AtPrime`
+- `#check IsLocalization.AtPrime`
+  - Typeclass for localization at a prime
+  - Import: `import Mathlib.RingTheory.Localization.AtPrime`
+- `#check Localization.AtPrime.instIsLocalRing`
+  - A_p is a local ring
+  - Import: `import Mathlib.RingTheory.Localization.AtPrime`
+- `#check IsLocalRing`
+  - Local ring typeclass (unique maximal ideal)
+  - Import: `import Mathlib.RingTheory.LocalRing.Basic`
+- `#check IsLocalRing.maximalIdeal`
+  - The unique maximal ideal of a local ring
+  - Import: `import Mathlib.RingTheory.LocalRing.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.LocalRing.Basic
+import Mathlib.RingTheory.Localization.AtPrime
+```

--- a/blobs/Lecture2/02_04_Example.refs.md
+++ b/blobs/Lecture2/02_04_Example.refs.md
@@ -1,0 +1,39 @@
+# References: Lecture2/02_04_Example
+
+**Coverage:** partially_covered
+
+k[x] localized at (x-2) is a DVR. Mathlib has DVR definition and polynomial rings. The specific example would need to be constructed.
+
+
+## Mathlib Declarations
+
+- `#check IsDiscreteValuationRing`
+  - DVR typeclass
+  - Import: `import Mathlib.RingTheory.DiscreteValuationRing.Basic`
+- `#check Polynomial`
+  - Polynomial ring k[x]
+  - Import: `import Mathlib.Algebra.Polynomial.Basic`
+- `#check Localization.AtPrime`
+  - Localization at prime for building k[x]_(x-2)
+  - Import: `import Mathlib.RingTheory.Localization.AtPrime`
+
+## External Sources
+
+- **Sutherland Number Theory Lecture 1 (FormalFrontier)** (lean4_library)
+  - Formalization of Lecture 1 of Sutherland's 18.785 Number Theory I. Contains DVR definitions (Def 1.10), valuation rings (Def 1.11), local rings (Def 1.12), residue fields (Def 1.13), Theorem 1.16 (7-w
+  - URL: https://github.com/FormalFrontier/Sutherland-NumberTheory-Lecture1-draft2
+  - Lake require: `Sutherland-NumberTheory-Lecture1` (scope: `FormalFrontier`)
+  - Note: Pinned to commit 33c1d4d (last commit on lean4 v4.28.0 / mathlib v4.28.0, matching this project's toolchain). Later commits upgraded to v4.29.0-rc8 and are incompatible.
+
+## Gap Analysis
+
+- **Gap:** Specific example: k[x] localized at (x-2) is a DVR. Needs assembly from Mathlib polynomial ring + localization + DVR infrastructure.
+- **External help:** Lecture 1 provides DVR definition and Theorem 1.16 characterization. Proof strategy from the blob file.
+
+## Suggested Imports
+
+```lean
+import Mathlib.Algebra.Polynomial.Basic
+import Mathlib.RingTheory.DiscreteValuationRing.Basic
+import Mathlib.RingTheory.Localization.AtPrime
+```

--- a/blobs/Lecture2/02_05_Example.refs.md
+++ b/blobs/Lecture2/02_05_Example.refs.md
@@ -1,0 +1,39 @@
+# References: Lecture2/02_05_Example
+
+**Coverage:** partially_covered
+
+Z_(p) is a DVR with p-adic valuation. Mathlib has padic valuation infrastructure but the specific localization-DVR example needs assembly.
+
+
+## Mathlib Declarations
+
+- `#check IsDiscreteValuationRing`
+  - DVR typeclass
+  - Import: `import Mathlib.RingTheory.DiscreteValuationRing.Basic`
+- `#check padicValNat`
+  - p-adic valuation on natural numbers
+  - Import: `import Mathlib.NumberTheory.Padics.PadicVal`
+- `#check ZMod`
+  - Z/pZ (finite fields F_p)
+  - Import: `import Mathlib.Data.ZMod.Basic`
+
+## External Sources
+
+- **Sutherland Number Theory Lecture 1 (FormalFrontier)** (lean4_library)
+  - Formalization of Lecture 1 of Sutherland's 18.785 Number Theory I. Contains DVR definitions (Def 1.10), valuation rings (Def 1.11), local rings (Def 1.12), residue fields (Def 1.13), Theorem 1.16 (7-w
+  - URL: https://github.com/FormalFrontier/Sutherland-NumberTheory-Lecture1-draft2
+  - Lake require: `Sutherland-NumberTheory-Lecture1` (scope: `FormalFrontier`)
+  - Note: Pinned to commit 33c1d4d (last commit on lean4 v4.28.0 / mathlib v4.28.0, matching this project's toolchain). Later commits upgraded to v4.29.0-rc8 and are incompatible.
+
+## Gap Analysis
+
+- **Gap:** Specific example: Z_(p) is a DVR with p-adic valuation. Mathlib has padic infrastructure but assembly needed.
+- **External help:** Lecture 1 DVR definitions. Mathlib padic valuation.
+
+## Suggested Imports
+
+```lean
+import Mathlib.Data.ZMod.Basic
+import Mathlib.NumberTheory.Padics.PadicVal
+import Mathlib.RingTheory.DiscreteValuationRing.Basic
+```

--- a/blobs/Lecture2/02_05a_Discussion.refs.md
+++ b/blobs/Lecture2/02_05a_Discussion.refs.md
@@ -1,0 +1,32 @@
+# References: Lecture2/02_05a_Discussion
+
+**Coverage:** fully_covered
+
+Module localization S⁻¹M, tensor product equivalence S⁻¹M ≅ M ⊗_A S⁻¹A.
+
+
+## Mathlib Declarations
+
+- `#check LocalizedModule`
+  - S⁻¹M as a type
+  - Import: `import Mathlib.RingTheory.Localization.Module`
+- `#check IsLocalizedModule`
+  - Typeclass for module localization
+  - Import: `import Mathlib.RingTheory.Localization.Module`
+- `#check LocalizedModule.mk`
+  - Constructor m/s for localized module elements
+  - Import: `import Mathlib.RingTheory.Localization.Module`
+- `#check LocalizedModule.equivTensorProduct`
+  - S⁻¹M ≃ₗ M ⊗_A S⁻¹A
+  - Import: `import Mathlib.RingTheory.Localization.Module`
+
+## External Sources
+
+- **Artin, Algebra (2nd ed.)** (textbook)
+  - The lecture cites [2, Prop. 3.5] for the tensor-localization equivalence S⁻¹M ≅ M ⊗_A S⁻¹A, and [2, Prop. 3.11] for contraction/extension and prime ideal correspondence. These are in Mathlib but the t
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.Localization.Module
+```

--- a/blobs/Lecture2/02_06_Proposition.refs.md
+++ b/blobs/Lecture2/02_06_Proposition.refs.md
@@ -1,0 +1,23 @@
+# References: Lecture2/02_06_Proposition
+
+**Coverage:** partially_covered
+
+Proposition 2.6 (M = ∩ M_p over all primes). Mathlib has related results for ideals in Dedekind domains but the general submodule-of-vector-space version may need custom proof.
+
+
+## Mathlib Declarations
+
+- `#check Submodule.iInf_localization_eq_bot (Maximal)`
+  - Related intersection-of-localizations results for Dedekind domains
+  - Import: `import Mathlib.RingTheory.Spectrum.Maximal.Localization`
+
+## Gap Analysis
+
+- **Gap:** General submodule intersection: M = ∩_p M_p. Mathlib has Dedekind domain version but not general integral domain version.
+- **External help:** Must be proved from scratch following the book's proof. No external Lean source found.
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.Spectrum.Maximal.Localization
+```

--- a/blobs/Lecture2/02_06a_Discussion.refs.md
+++ b/blobs/Lecture2/02_06a_Discussion.refs.md
@@ -1,0 +1,22 @@
+# References: Lecture2/02_06a_Discussion
+
+**Coverage:** partially_covered
+
+Localization of an ideal as module = extension of ideal. Mathlib has both concepts but the explicit identification I_p = IA_p may need assembly.
+
+
+## Mathlib Declarations
+
+- `#check Ideal.map`
+  - Ideal extension IA_p
+  - Import: `import Mathlib.RingTheory.Ideal.Operations`
+- `#check LocalizedModule`
+  - Module localization I_p
+  - Import: `import Mathlib.RingTheory.Localization.Module`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.Ideal.Operations
+import Mathlib.RingTheory.Localization.Module
+```

--- a/blobs/Lecture2/02_07_Corollary.refs.md
+++ b/blobs/Lecture2/02_07_Corollary.refs.md
@@ -1,0 +1,23 @@
+# References: Lecture2/02_07_Corollary
+
+**Coverage:** partially_covered
+
+Corollary 2.7: I = ∩ I_p for ideals in an integral domain. Mathlib has the ideal version for Dedekind domains (iInf_localization_eq_bot). The general integral domain version may need proof.
+
+
+## Mathlib Declarations
+
+- `#check IsDedekindDomain.HeightOneSpectrum.iInf_localization_eq_bot`
+  - Intersection of localizations of ideals in Dedekind domains
+  - Import: `import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas`
+
+## Gap Analysis
+
+- **Gap:** I = ∩_p I_p for ideals in integral domain. General version may need proof.
+- **External help:** Follows from 02_06_Proposition. Book proof strategy.
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
+```

--- a/blobs/Lecture2/02_08_Example.refs.md
+++ b/blobs/Lecture2/02_08_Example.refs.md
@@ -1,0 +1,23 @@
+# References: Lecture2/02_08_Example
+
+**Coverage:** partially_covered
+
+Z = ∩ Z_(p) in Q. This is a concrete instance of Corollary 2.7. Needs assembly from localization infrastructure.
+
+
+## Mathlib Declarations
+
+- `#check Localization.AtPrime`
+  - Z_(p) construction
+  - Import: `import Mathlib.RingTheory.Localization.AtPrime`
+
+## Gap Analysis
+
+- **Gap:** Z = ∩ Z_(p) in Q. Concrete instance of Corollary 2.7.
+- **External help:** Assembly from Mathlib localization infrastructure.
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.Localization.AtPrime
+```

--- a/blobs/Lecture2/02_09_Proposition.refs.md
+++ b/blobs/Lecture2/02_09_Proposition.refs.md
@@ -1,0 +1,44 @@
+# References: Lecture2/02_09_Proposition
+
+**Coverage:** fully_covered
+
+Proposition 2.9: Noetherian + integrally closed + dim ≤ 1 ↔ all localizations at nonzero primes are DVRs. This is exactly the Dedekind domain characterization in Mathlib.
+
+
+## Mathlib Declarations
+
+- `#check IsDedekindDomain`
+  - Dedekind domain: noetherian, dim ≤ 1, integrally closed
+  - Import: `import Mathlib.RingTheory.DedekindDomain.Basic`
+- `#check IsDedekindDomainDvr`
+  - DVR characterization of Dedekind domains
+  - Import: `import Mathlib.RingTheory.DedekindDomain.Dvr`
+- `#check IsDedekindDomain.isDedekindDomainDvr`
+  - IsDedekindDomain → IsDedekindDomainDvr
+  - Import: `import Mathlib.RingTheory.DedekindDomain.Dvr`
+- `#check IsDedekindDomainDvr.ring_dimensionLEOne`
+  - DVR localizations → dimension ≤ 1
+  - Import: `import Mathlib.RingTheory.DedekindDomain.Dvr`
+- `#check IsIntegrallyClosed`
+  - Integrally closed typeclass
+  - Import: `import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic`
+- `#check Ring.DimensionLEOne`
+  - Krull dimension ≤ 1 typeclass
+  - Import: `import Mathlib.RingTheory.Ideal.Height`
+
+## External Sources
+
+- **Sutherland Number Theory Lecture 1 (FormalFrontier)** (lean4_library)
+  - Formalization of Lecture 1 of Sutherland's 18.785 Number Theory I. Contains DVR definitions (Def 1.10), valuation rings (Def 1.11), local rings (Def 1.12), residue fields (Def 1.13), Theorem 1.16 (7-w
+  - URL: https://github.com/FormalFrontier/Sutherland-NumberTheory-Lecture1-draft2
+  - Lake require: `Sutherland-NumberTheory-Lecture1` (scope: `FormalFrontier`)
+  - Note: Pinned to commit 33c1d4d (last commit on lean4 v4.28.0 / mathlib v4.28.0, matching this project's toolchain). Later commits upgraded to v4.29.0-rc8 and are incompatible.
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.DedekindDomain.Basic
+import Mathlib.RingTheory.DedekindDomain.Dvr
+import Mathlib.RingTheory.Ideal.Height
+import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
+```

--- a/blobs/Lecture2/02_10_Definition.refs.md
+++ b/blobs/Lecture2/02_10_Definition.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_10_Definition
+
+**Coverage:** fully_covered
+
+Definition 2.10: Dedekind domain. Directly corresponds to Mathlib's IsDedekindDomain.
+
+
+## Mathlib Declarations
+
+- `#check IsDedekindDomain`
+  - A Dedekind domain is a noetherian, integrally closed domain of dimension ≤ 1
+  - Import: `import Mathlib.RingTheory.DedekindDomain.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.DedekindDomain.Basic
+```

--- a/blobs/Lecture2/02_11_Corollary.refs.md
+++ b/blobs/Lecture2/02_11_Corollary.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_11_Corollary
+
+**Coverage:** fully_covered
+
+Corollary 2.11: Every PID is a Dedekind domain. Directly in Mathlib.
+
+
+## Mathlib Declarations
+
+- `#check IsPrincipalIdealRing.isDedekindDomain`
+  - Every PID is a Dedekind domain
+  - Import: `import Mathlib.RingTheory.DedekindDomain.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.DedekindDomain.Basic
+```

--- a/blobs/Lecture2/02_12_Remark.refs.md
+++ b/blobs/Lecture2/02_12_Remark.refs.md
@@ -1,0 +1,27 @@
+# References: Lecture2/02_12_Remark
+
+**Coverage:** partially_covered
+
+Remark 2.12 discusses PID/UFD/Dedekind relationships. The key result (Dedekind + UFD → PID) is in Mathlib. The counterexamples (k[x,y] not Dedekind, Z[√(-13)] not UFD) would need construction.
+
+
+## Mathlib Declarations
+
+- `#check IsPrincipalIdealRing.of_isDedekindDomain_of_uniqueFactorizationMonoid`
+  - Dedekind domain + UFD → PID
+  - Import: `import Mathlib.RingTheory.DedekindDomain.PID`
+- `#check Zsqrtd`
+  - Z[√d] for d : ℤ (for Z[√(-13)] example)
+  - Import: `import Mathlib.NumberTheory.Zsqrtd.Basic`
+
+## Gap Analysis
+
+- **Gap:** Counterexamples: k[x,y] not Dedekind, Z[√(-13)] not UFD.
+- **External help:** Folklore results. Must be constructed. Z[√(-13)] available via Mathlib Zsqrtd.
+
+## Suggested Imports
+
+```lean
+import Mathlib.NumberTheory.Zsqrtd.Basic
+import Mathlib.RingTheory.DedekindDomain.PID
+```

--- a/blobs/Lecture2/02_12a_Discussion.refs.md
+++ b/blobs/Lecture2/02_12a_Discussion.refs.md
@@ -1,0 +1,30 @@
+# References: Lecture2/02_12a_Discussion
+
+**Coverage:** fully_covered
+
+Integral closure of Dedekind domain in finite separable extension is Dedekind. Directly in Mathlib.
+
+
+## Mathlib Declarations
+
+- `#check IsIntegralClosure.isDedekindDomain`
+  - Integral closure of Dedekind domain in finite separable extension is Dedekind
+  - Import: `import Mathlib.RingTheory.DedekindDomain.IntegralClosure`
+- `#check integralClosure`
+  - Integral closure of R in A
+  - Import: `import Mathlib.RingTheory.IntegralClosure.Algebra.Basic`
+
+## External Sources
+
+- **Sutherland Number Theory Lecture 1 (FormalFrontier)** (lean4_library)
+  - Formalization of Lecture 1 of Sutherland's 18.785 Number Theory I. Contains DVR definitions (Def 1.10), valuation rings (Def 1.11), local rings (Def 1.12), residue fields (Def 1.13), Theorem 1.16 (7-w
+  - URL: https://github.com/FormalFrontier/Sutherland-NumberTheory-Lecture1-draft2
+  - Lake require: `Sutherland-NumberTheory-Lecture1` (scope: `FormalFrontier`)
+  - Note: Pinned to commit 33c1d4d (last commit on lean4 v4.28.0 / mathlib v4.28.0, matching this project's toolchain). Later commits upgraded to v4.29.0-rc8 and are incompatible.
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.DedekindDomain.IntegralClosure
+import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
+```

--- a/blobs/Lecture2/02_13_Definition.refs.md
+++ b/blobs/Lecture2/02_13_Definition.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_13_Definition
+
+**Coverage:** fully_covered
+
+Definition 2.13: Fractional ideal = finitely generated A-submodule of K. Mathlib's FractionalIdeal uses the aI ⊆ A characterization.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal`
+  - Type of fractional ideals (A-submodules I of K with aI ⊆ A for some nonzero a)
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_14_Lemma.refs.md
+++ b/blobs/Lecture2/02_14_Lemma.refs.md
@@ -1,0 +1,21 @@
+# References: Lecture2/02_14_Lemma
+
+**Coverage:** fully_covered
+
+Lemma 2.14: I is f.g. A-submodule of K iff aI ⊆ A for some nonzero a. This is built into Mathlib's FractionalIdeal definition.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal`
+  - Uses the aI ⊆ A characterization as its definition
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+- `#check FractionalIdeal.isFractional`
+  - Every fractional ideal satisfies the aI ⊆ A property
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_16_Corollary.refs.md
+++ b/blobs/Lecture2/02_16_Corollary.refs.md
@@ -1,0 +1,21 @@
+# References: Lecture2/02_16_Corollary
+
+**Coverage:** fully_covered
+
+Corollary 2.16: Every fractional ideal = (1/a)I. Follows from Mathlib's FractionalIdeal.isFractional.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal.isFractional`
+  - Existence of a with aI ⊆ A, equivalent to I = (1/a)(aI)
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+- `#check FractionalIdeal.coeIdeal`
+  - Embedding of ideals into fractional ideals
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_17_Definition.refs.md
+++ b/blobs/Lecture2/02_17_Definition.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_17_Definition
+
+**Coverage:** fully_covered
+
+Definition 2.17: Principal fractional ideal (x) = xA. Directly in Mathlib.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal.spanSingleton`
+  - Principal fractional ideal (x) = span {x}
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_17a_Discussion.refs.md
+++ b/blobs/Lecture2/02_17a_Discussion.refs.md
@@ -1,0 +1,24 @@
+# References: Lecture2/02_17a_Discussion
+
+**Coverage:** fully_covered
+
+Operations on fractional ideals: sum, product, quotient (colon ideal). All in Mathlib.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal.instAdd`
+  - Sum of fractional ideals I + J
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+- `#check FractionalIdeal.instMul`
+  - Product of fractional ideals IJ
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+- `#check FractionalIdeal.instDiv`
+  - Division/quotient I / J (colon ideal)
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_18_Lemma.refs.md
+++ b/blobs/Lecture2/02_18_Lemma.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_18_Lemma
+
+**Coverage:** fully_covered
+
+Lemma 2.18: I ÷ J is a fractional ideal. Built into the return type of FractionalIdeal division in Mathlib.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal.div_of_ne_zero`
+  - Division of fractional ideals returns a fractional ideal
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_19_Definition.refs.md
+++ b/blobs/Lecture2/02_19_Definition.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_19_Definition
+
+**Coverage:** fully_covered
+
+Definition 2.19: Invertible fractional ideal (IJ = A). Mathlib has Inv instance and mul_inv_cancel for Dedekind domains.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal.mul_inv_cancel`
+  - I * I⁻¹ = 1 for nonzero fractional ideals in Dedekind domains
+  - Import: `import Mathlib.RingTheory.DedekindDomain.Ideal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.DedekindDomain.Ideal.Basic
+```

--- a/blobs/Lecture2/02_20_Lemma.refs.md
+++ b/blobs/Lecture2/02_20_Lemma.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_20_Lemma
+
+**Coverage:** fully_covered
+
+Lemma 2.20: I invertible iff I(A ÷ I) = A, with I⁻¹ = A ÷ I. In Mathlib as inv_eq.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal.inv_eq`
+  - I⁻¹ = 1 / I (i.e., A ÷ I)
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_21_Example.refs.md
+++ b/blobs/Lecture2/02_21_Example.refs.md
@@ -1,0 +1,29 @@
+# References: Lecture2/02_21_Example
+
+**Coverage:** not_covered
+
+Example 2.21: A = Z + 2iZ, I = 2Z[i] is not invertible as A-ideal. This specific example needs custom construction. Mathlib has GaussianInt (Z[i]) but not the subring Z + 2iZ.
+
+
+## Mathlib Declarations
+
+- `#check GaussianInt`
+  - Z[i] (Gaussian integers)
+  - Import: `import Mathlib.NumberTheory.Zsqrtd.GaussianInt`
+
+## External Sources
+
+- **Mathlib GaussianInt module** (mathlib_submodule)
+  - Mathlib defines GaussianInt (Z[i]) and its ring structure. Example 2.21 needs the subring A = Z + 2iZ ⊂ Z[i], which is NOT in Mathlib and must be constructed from scratch.
+  - Note: Z[i] is available; the subring Z + 2iZ and the proof that I = 2Z[i] is not invertible as an A-ideal must be built custom. This is the only 'not_covered' item.
+
+## Gap Analysis
+
+- **Gap:** A = Z + 2iZ, I = 2Z[i] not invertible. Subring Z + 2iZ not in Mathlib.
+- **External help:** GaussianInt from Mathlib provides Z[i]. The subring and non-invertibility proof must be built from scratch.
+
+## Suggested Imports
+
+```lean
+import Mathlib.NumberTheory.Zsqrtd.GaussianInt
+```

--- a/blobs/Lecture2/02_21a_Discussion.refs.md
+++ b/blobs/Lecture2/02_21a_Discussion.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_21a_Discussion
+
+**Coverage:** partially_covered
+
+Fractional ideals form abelian monoid; invertible ones form abelian group. The group structure is in Mathlib.
+
+
+## Mathlib Declarations
+
+- `#check FractionalIdeal.instCommMonoid`
+  - Commutative monoid structure on fractional ideals
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_22_Definition.refs.md
+++ b/blobs/Lecture2/02_22_Definition.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_22_Definition
+
+**Coverage:** fully_covered
+
+Definition 2.22: Ideal group I_A = group of invertible fractional ideals. In Mathlib as the units of FractionalIdeal.
+
+
+## Mathlib Declarations
+
+- `#check (FractionalIdeal (nonZeroDivisors A) K)ˣ`
+  - Units of fractional ideals = group of invertible fractional ideals
+  - Import: `import Mathlib.RingTheory.FractionalIdeal.Basic`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.FractionalIdeal.Basic
+```

--- a/blobs/Lecture2/02_22a_Discussion.refs.md
+++ b/blobs/Lecture2/02_22a_Discussion.refs.md
@@ -1,0 +1,18 @@
+# References: Lecture2/02_22a_Discussion
+
+**Coverage:** fully_covered
+
+Principal fractional ideals P_A form subgroup. In Mathlib as toPrincipalIdeal.
+
+
+## Mathlib Declarations
+
+- `#check toPrincipalIdeal`
+  - Homomorphism from K× to fractional ideal group (principal ideals)
+  - Import: `import Mathlib.RingTheory.ClassGroup`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.ClassGroup
+```

--- a/blobs/Lecture2/02_23_Definition.refs.md
+++ b/blobs/Lecture2/02_23_Definition.refs.md
@@ -1,0 +1,21 @@
+# References: Lecture2/02_23_Definition
+
+**Coverage:** fully_covered
+
+Definition 2.23: Ideal class group cl(A) = I_A / P_A. Directly in Mathlib as ClassGroup.
+
+
+## Mathlib Declarations
+
+- `#check ClassGroup`
+  - The ideal class group (quotient of invertible fractional ideals by principal ones)
+  - Import: `import Mathlib.RingTheory.ClassGroup`
+- `#check ClassGroup.equiv`
+  - ClassGroup R ≃* (FractionalIdeal)ˣ ⧸ (toPrincipalIdeal R K).range
+  - Import: `import Mathlib.RingTheory.ClassGroup`
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.ClassGroup
+```

--- a/blobs/Lecture2/02_24_Example.refs.md
+++ b/blobs/Lecture2/02_24_Example.refs.md
@@ -1,0 +1,38 @@
+# References: Lecture2/02_24_Example
+
+**Coverage:** partially_covered
+
+Example 2.24: DVR has trivial class group. The general framework exists; the specific DVR class group triviality result needs assembly.
+
+
+## Mathlib Declarations
+
+- `#check IsDiscreteValuationRing`
+  - DVR typeclass
+  - Import: `import Mathlib.RingTheory.DiscreteValuationRing.Basic`
+- `#check ClassGroup`
+  - Class group for the triviality statement
+  - Import: `import Mathlib.RingTheory.ClassGroup`
+- `#check ClassGroup.mk0_eq_one_iff`
+  - ClassGroup.mk0 I = 1 ↔ I is principal (for Dedekind domains)
+  - Import: `import Mathlib.RingTheory.ClassGroup`
+
+## External Sources
+
+- **Sutherland Number Theory Lecture 1 (FormalFrontier)** (lean4_library)
+  - Formalization of Lecture 1 of Sutherland's 18.785 Number Theory I. Contains DVR definitions (Def 1.10), valuation rings (Def 1.11), local rings (Def 1.12), residue fields (Def 1.13), Theorem 1.16 (7-w
+  - URL: https://github.com/FormalFrontier/Sutherland-NumberTheory-Lecture1-draft2
+  - Lake require: `Sutherland-NumberTheory-Lecture1` (scope: `FormalFrontier`)
+  - Note: Pinned to commit 33c1d4d (last commit on lean4 v4.28.0 / mathlib v4.28.0, matching this project's toolchain). Later commits upgraded to v4.29.0-rc8 and are incompatible.
+
+## Gap Analysis
+
+- **Gap:** DVR has trivial class group. Framework exists, specific result needs assembly.
+- **External help:** Lecture 1 DVR characterization. Mathlib class group machinery.
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.ClassGroup
+import Mathlib.RingTheory.DiscreteValuationRing.Basic
+```

--- a/blobs/Lecture2/02_25_Remark.refs.md
+++ b/blobs/Lecture2/02_25_Remark.refs.md
@@ -1,0 +1,27 @@
+# References: Lecture2/02_25_Remark
+
+**Coverage:** partially_covered
+
+Remark 2.25: Dedekind domain is UFD iff cl(A) trivial. Mathlib has Dedekind + UFD → PID and the class group machinery, but the exact biconditional may need assembly.
+
+
+## Mathlib Declarations
+
+- `#check IsPrincipalIdealRing.of_isDedekindDomain_of_uniqueFactorizationMonoid`
+  - Dedekind + UFD → PID
+  - Import: `import Mathlib.RingTheory.DedekindDomain.PID`
+- `#check ClassGroup.mk0_eq_one_iff`
+  - Relates class group triviality to principalness of ideals
+  - Import: `import Mathlib.RingTheory.ClassGroup`
+
+## Gap Analysis
+
+- **Gap:** Dedekind domain is UFD iff cl(A) trivial. Biconditional may need assembly.
+- **External help:** Mathlib has both directions separately. Assembly needed.
+
+## Suggested Imports
+
+```lean
+import Mathlib.RingTheory.ClassGroup
+import Mathlib.RingTheory.DedekindDomain.PID
+```


### PR DESCRIPTION
Closes #--issue

Session: `e9c90743-b729-48ca-b40d-7be7104b8f35`

9c88b97 Stage 2.6: Reference attachment for all items (Lecture 2)

🤖 Prepared with Claude Code