### PR TITLE
Scaffold 02_10_Definition: Dedekind Domain

### DIFF
--- a/SutherlandNumberTheoryLecture2/Lecture2/02_10_Definition.lean
+++ b/SutherlandNumberTheoryLecture2/Lecture2/02_10_Definition.lean
@@ -1,7 +1,61 @@
 import Mathlib
 
 /-!
-# Definition 2.10
+# Definition 2.10: Dedekind Domain
 
-See `blobs/Lecture2/02_10_Definition.md` for the source text.
+A noetherian domain satisfying either of the equivalent properties of
+Proposition 2.9 is called a *Dedekind domain*. Concretely, a Dedekind domain
+is a noetherian, integrally closed domain of Krull dimension at most one.
+
+## Mathlib correspondence
+
+Mathlib defines `IsDedekindDomain` as `IsDomain A ∧ IsDedekindRing A`, where
+`IsDedekindRing A` extends `IsNoetherian A A`, `Ring.DimensionLEOne A`, and
+`IsIntegralClosure A A (FractionRing A)`. This matches the book's definition
+exactly (noetherian + integrally closed + dim ≤ 1).
 -/
+
+section DedekindDomain
+
+/-! ### The definition
+
+**Definition 2.10.** A Dedekind domain is a noetherian, integrally closed domain
+of Krull dimension ≤ 1. This is Mathlib's `IsDedekindDomain`. -/
+
+#check @IsDedekindDomain  -- recall: (A : Type*) → [CommRing A] → Prop
+
+/-! ### Component properties
+
+The book defines a Dedekind domain as a noetherian domain satisfying the equivalent
+conditions of Proposition 2.9: (i) every localization at a nonzero prime is a DVR, or
+(ii) integrally closed with dim ≤ 1. Mathlib encodes condition (ii) directly as three
+typeclasses. -/
+
+-- A Dedekind domain is noetherian: every ideal is finitely generated.
+#check @IsNoetherianRing
+
+-- Krull dimension ≤ 1: every nonzero prime ideal is maximal.
+#check @Ring.DimensionLEOne
+
+-- A Dedekind domain is integrally closed in its fraction field.
+#check @IsIntegrallyClosed
+
+/-! ### Instances: a Dedekind domain has all three properties -/
+
+variable {A : Type*} [CommRing A] [IsDomain A] [IsDedekindDomain A]
+
+example : IsNoetherianRing A := inferInstance
+
+example : Ring.DimensionLEOne A := inferInstance
+
+example : IsIntegrallyClosed A := inferInstance
+
+/-! ### Characterization theorem (Mathlib form)
+
+The `iff` characterization shows the definition is independent of the
+choice of fraction field. This is the Mathlib form of the equivalence
+in Proposition 2.9 + Definition 2.10. -/
+
+#check @isDedekindRing_iff
+
+end DedekindDomain

--- a/progress/2026-03-26T01-50-34Z.md
+++ b/progress/2026-03-26T01-50-34Z.md
@@ -1,0 +1,28 @@
+## Accomplished
+
+- Scaffolded `02_10_Definition.lean` (Dedekind Domain) — issue #63
+- Fully covered by Mathlib's `IsDedekindDomain` typeclass
+- Used `#check` + `example` pattern instead of `recall` (recall has universe mismatch issues with polymorphic Mathlib declarations)
+- Coverage: definition, three component properties (noetherian, dim ≤ 1, integrally closed), inferInstance examples, and `isDedekindRing_iff` characterization
+- `lake build` passes with no errors
+- Updated `progress/items.json`: status → `scaffolded`
+
+## Current frontier
+
+- Item `02_10_Definition` scaffolded; PR to be created
+- 7 other scaffolding issues remain unclaimed (#64–#70)
+
+## Overall project progress
+
+- Stage 3.1 setup complete (PR #61 merged — skeleton .lean files for all 36 items)
+- 3 items marked `non_formalizable`
+- 1 item now `scaffolded` (02_10_Definition)
+- Remaining items at `scaffolding_ready`
+
+## Next step
+
+- Pick another scaffolding issue (suggest #64 Fractional Ideal or #65 Prime Ideal Correspondence — both fully covered by Mathlib)
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -98,10 +98,10 @@
     "notes": ""
   },
   "Lecture2/02_10_Definition": {
-    "status": "scaffolding_ready",
+    "status": "scaffolded",
     "last_updated": "2026-03-26",
     "pr": "",
-    "notes": ""
+    "notes": "Fully covered by Mathlib IsDedekindDomain. Used #check + example pattern (recall has universe issues with polymorphic defs). Covers: definition, three component properties (noetherian, dim ≤ 1, integrally closed), instances, and iff characterization."
   },
   "Lecture2/02_11_Corollary": {
     "status": "scaffolding_ready",


### PR DESCRIPTION
## Summary
- Scaffolds `02_10_Definition.lean` — the Dedekind domain definition (issue #63)
- Fully covered by Mathlib's `IsDedekindDomain` typeclass
- Uses `#check` + `example` pattern (recall has universe issues with polymorphic Mathlib defs)
- Covers: definition, three component properties (noetherian, dim ≤ 1, integrally closed), `inferInstance` examples, and `isDedekindRing_iff` characterization
- `lake build` passes

Closes #63

🤖 Prepared with Claude Code